### PR TITLE
Don't show nicknames for now

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -31,17 +31,18 @@ def getFormattedOutput(username):
     - Places a "\u200c" character after nickname
       -  prevent slack from tagging someone by name
       - still show name without visible modification"""
-    uuid = getPlayerUUID(username)
-    try:
-        with open(f'HCCore/players/{uuid}.json') as f:
-            # Gathers nick from HCCore's JSON file
-            nick = json.load(f)['nickname']
-            if nick == None:  # if the Nick doesn't exist, return just the username
-                output = f'- {username[:1]}\u200c{username[1:]}\n'
-            else:
-                output = f'- {nick[:1]}\u200c{nick[1:]} ({username[:1]}\u200c{username[1:]})\n'
-    except FileNotFoundError:
-        output = f'- {username[:1]}\u200c{username[1:]}\n'
+#     uuid = getPlayerUUID(username)
+#     try:
+#         with open(f'HCCore/players/{uuid}.json') as f:
+#             # Gathers nick from HCCore's JSON file
+#             nick = json.load(f)['nickname']
+#             if nick == None:  # if the Nick doesn't exist, return just the username
+#                 output = f'- {username[:1]}\u200c{username[1:]}\n'
+#             else:
+#                 output = f'- {nick[:1]}\u200c{nick[1:]} ({username[:1]}\u200c{username[1:]})\n'
+#     except FileNotFoundError:
+#         output = f'- {username[:1]}\u200c{username[1:]}\n'
+    output = f'- {username[:1]}\u200c{username[1:]}\n'
 
     return output
 


### PR DESCRIPTION
Will allow /players to stay online by temporarily removing nicknames from the results.