### PR TITLE
Fix incorrect markdown formatting of nicks

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -47,8 +47,8 @@ def getFormattedOutput(reName, realName):
         ign = '\u200c'.join(reName[i:i+1]
                             for i in range(0, len(reName), 1))
         # Removes _ from nicknames, which can cause potential formatting issues in slack
-        nick = re.sub(r'[\_\~\*\]', '', nick)
-        ign = re.sub(r'[\_\~\*]', '', nick)  # Same as above, but for usernames
+        nick = re.sub(r'[_~*]', '', nick)
+        ign = re.sub(r'[_~*]', '', nick)  # Same as above, but for usernames
         if nick == None:  # if the Nick doesn't exist, return just the username
             output = f'- {ign}'
         else:

--- a/commands.py
+++ b/commands.py
@@ -48,7 +48,7 @@ def getFormattedOutput(reName, realName):
                             for i in range(0, len(reName), 1))
         # Removes _ from nicknames, which can cause potential formatting issues in slack
         nick = re.sub(r'[_~*]', '', nick)
-        ign = re.sub(r'[_~*]', '', nick)  # Same as above, but for usernames
+        ign = re.sub(r'[_~*]', '', ign)  # Same as above, but for usernames
         if nick == None:  # if the Nick doesn't exist, return just the username
             output = f'- {ign}'
         else:

--- a/commands.py
+++ b/commands.py
@@ -44,9 +44,11 @@ def getFormattedOutput(reName, realName):
 
     try:
         nick = getNick(uuid)
-
         ign = '\u200c'.join(reName[i:i+1]
                             for i in range(0, len(reName), 1))
+        # Removes _ from nicknames, which can cause potential formatting issues in slack
+        nick = re.sub(r'[\_\~\*\]', '', nick)
+        ign = re.sub(r'[\_\~\*]', '', nick)  # Same as above, but for usernames
         if nick == None:  # if the Nick doesn't exist, return just the username
             output = f'- {ign}'
         else:


### PR DESCRIPTION
Fixes the incorrect formatting of nicks by stripping all potentially bad characters from names. It isn't ideal, but since slack has removed the `parse` keyword from postMessage it's the best possible option.
