### PR TITLE
Switch to message shortcut + Add multiple posting methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ users/
 .vscode/
 __pycache__/
 test*
+
+.env

--- a/commands.py
+++ b/commands.py
@@ -1,4 +1,3 @@
-from dotenv import load_dotenv
 import json
 import os
 import sys
@@ -17,7 +16,6 @@ slackBotToken = os.environ['BOT_OAUTH_TOKEN']
 playerDataApi = os.environ['PLAYER_DATA_API']
 censoredWords = os.environ['CENSORED_WORDS']
 
-load_dotenv()
 
 slack_client = slack.WebClient(
     token=slackBotToken
@@ -297,6 +295,6 @@ def delete():
 if __name__ == '__main__':
     app.run(
         host='0.0.0.0',
-        debug=True,
+        debug=False,
         port=8000
     )

--- a/commands.py
+++ b/commands.py
@@ -140,10 +140,6 @@ def buildFullMessage(channel, user):
 
             ])
 
-    # Remove the divider after the last section
-    if len(message) > 1:
-        del message[-2]
-
     return message
 
 
@@ -218,25 +214,38 @@ def players():
 
     channel = request.form['channel_id']
     user = request.form['user_id']
+    response_url = request.form['response_url']
 
     msg = buildFullMessage(channel, user)
     fallbackText = f'Message from @Steve, requested by <@{user}>'
 
     try:  # Attempts to post message in channel
-        postRichChatMessage(channel=channel, blocks=msg, text=fallbackText)
+        requests.post(
+            response_url,
+            headers={
+                'Content-Type': 'application/json',
+            },
+            data={
+                'channel': channel,
+                'blocks': msg,
+                'text': fallbackText
+            }
+        )
     except:
         try:  # If it cannot post in the channel, it will attempt to join the channel
             joinChannel(
                 channel=channel)
-            postRichChatMessage(channel=channel, blocks=msg)
+            postRichChatMessage(
+                channel=channel,
+                blocks=msg,
+                text=fallbackText
+            )
         except:  # If it cannot join the channel, it will DM the command runner
             postRichChatMessage(
                 channel=user,
-                blocks=msg
+                blocks=msg,
+                text=fallbackText
             )
-            postPlainChatMessage(
-                channel=user,
-                text=f'In order to use the bot in the channel, please invite <@UKD6P483E>!')
 
     # Returns 200 to make slack happy and avoid operation_timeout
     return ('', 200)

--- a/commands.py
+++ b/commands.py
@@ -9,9 +9,6 @@ from flask import Flask, abort, jsonify, request
 from mcstatus import MinecraftServer
 import requests
 
-from dotenv import load_dotenv
-
-load_dotenv()
 # get configs
 slackVerifyToken = os.environ['TOKEN']
 slackTeamId = os.environ['TEAM_ID']

--- a/commands.py
+++ b/commands.py
@@ -1,3 +1,4 @@
+from dotenv import load_dotenv
 import json
 import os
 import sys
@@ -16,6 +17,7 @@ slackBotToken = os.environ['BOT_OAUTH_TOKEN']
 playerDataApi = os.environ['PLAYER_DATA_API']
 censoredWords = os.environ['CENSORED_WORDS']
 
+load_dotenv()
 
 slack_client = slack.WebClient(
     token=slackBotToken
@@ -215,6 +217,7 @@ def players():
     channel = request.form['channel_id']
     user = request.form['user_id']
     response_url = request.form['response_url']
+    print(request.form)
 
     msg = buildFullMessage(channel, user)
     fallbackText = f'Message from @Steve, requested by <@{user}>'
@@ -225,10 +228,11 @@ def players():
             headers={
                 'Content-Type': 'application/json',
             },
-            data={
+            json={
                 'channel': channel,
                 'blocks': msg,
-                'text': fallbackText
+                'text': fallbackText,
+                'response_type': 'in_channel'
             }
         )
     except:
@@ -293,6 +297,6 @@ def delete():
 if __name__ == '__main__':
     app.run(
         host='0.0.0.0',
-        debug=False,
+        debug=True,
         port=8000
     )

--- a/commands.py
+++ b/commands.py
@@ -129,20 +129,6 @@ def buildFullMessage(channel, user):
                     'type': 'divider'
                 },
                 {
-                    "type": "actions",
-                    "elements": [
-                            {
-                                "type": "button",
-                                "text": {
-                                        "type": "plain_text",
-                                        "text": "Delete",
-                                        "emoji": True
-                                },
-                                "style": "danger"
-                            }
-                    ]
-                },
-                {
                     'type': 'context',
                     'elements': [
                         {
@@ -156,7 +142,7 @@ def buildFullMessage(channel, user):
 
     # Remove the divider after the last section
     if len(message) > 1:
-        del message[-3]
+        del message[-2]
 
     return message
 

--- a/commands.py
+++ b/commands.py
@@ -249,9 +249,8 @@ def delete():
     # Grabs and parses payload from button
     payload = json.loads(request.form.to_dict()['payload'])
 
-    # Parses original message sender from message - slack decided to up the number of caracters in their UIDs, and I didn't feel like writing regex for this.
     # gets the specific text block that the UID is in
-    origMessageSignature = payload['message']['blocks'][2]['elements'][0]['text']
+    origMessageSignature = payload['message']['blocks'][-1]['elements'][0]['text']
     # gathers the UID from there using regex
     origMessageSender = re.search(r'\<\@(.+)\>', origMessageSignature).group(1)
     # gathers the UID of the person who asked for the reload

--- a/commands.py
+++ b/commands.py
@@ -218,7 +218,6 @@ def players():
     channel = request.form['channel_id']
     user = request.form['user_id']
     response_url = request.form['response_url']
-    print(request.form)
 
     msg = buildFullMessage(channel, user)
     fallbackText = f'Message from @Steve, requested by <@{user}>'
@@ -299,7 +298,7 @@ def delete():
         postEphemeralMessage(
             channel=channel,
             user=deleteReqSender,
-            text=f'Sorry, you can\'t do that!',
+            text=f'Sorry, you can\'t do that!'
         )
 
     return jsonify({


### PR DESCRIPTION
This update allows for sending messages via webhook when the bot isn't in a channel. Unfortunately, slack puts weird restrictions on webhooks - they can be deleted by an admin token, but not by the user token. Thus this update also allows for deleting a message based on an admin token - which should work within DMs, though again through arbitrary rules, not in private channels.

It also removes the delete button and replaces it with a message shortcut; the new Android update makes buttons comically large, and I didn't want it taking up a very large amount of spaceon the screen when it didn't need to.

- remove bad dependencies
- add multiple forms of deletion and message posting
- add webhook compat
- update devel dependencies
- send via response_url correctly
- convert to using response_url, so the message can be posted anywhere
- clarify name processing
- change to message shortcut instead of delete button
